### PR TITLE
Distcp with snapshots Ozone change

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -671,6 +671,18 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
     this.lock.writeLock().lock();
   }
 
+  @Override
+  public void readUnlock(String opName) {
+    // not used anywhere, implemented as part of interface.
+    this.lock.writeLock().lock();
+  }
+
+  @Override
+  public void writeUnlock(String opName) {
+    // not used anywhere, implemented as part of interface.
+    this.lock.writeLock().unlock();
+  }
+
   /**
    * Release write lock.
    */

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBCheckpointManager.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBCheckpointManager.java
@@ -113,7 +113,8 @@ public class RDBCheckpointManager implements Closeable {
    * Wait for checkpoint directory to be created for 5 secs with 100 millis
    * poll interval.
    */
-  private void waitForCheckpointDirectoryExist(File file) throws IOException {
+  public static void waitForCheckpointDirectoryExist(File file)
+      throws IOException {
     Instant start = Instant.now();
     try {
       with().atMost(POLL_MAX_DURATION)

--- a/hadoop-ozone/common/pom.xml
+++ b/hadoop-ozone/common/pom.xml
@@ -109,6 +109,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
     </dependency>
+      <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-hdfs-client</artifactId>
+      </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/snapshot/SnapshotDiffReport.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/snapshot/SnapshotDiffReport.java
@@ -18,216 +18,108 @@
 
 package org.apache.hadoop.ozone.snapshot;
 
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SnapshotDiffReportProto;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DiffReportEntryProto;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DiffReportEntryProto.DiffTypeProto;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.OFSPath;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
+
 /**
- * Snapshot diff report.
+ * Snapshot Diff Report.
  */
-public class SnapshotDiffReport {
+public class SnapshotDiffReport
+    extends org.apache.hadoop.hdfs.protocol.SnapshotDiffReport {
 
-  private static final String LINE_SEPARATOR = System.getProperty(
-      "line.separator", "\n");
+  private static final String LINE_SEPARATOR =
+      System.getProperty("line.separator", "\n");
 
-  /**
-   * Types of the difference, which include CREATE, MODIFY, DELETE, and RENAME.
-   * Each type has a label for representation:
-   * +  CREATE
-   * M  MODIFY
-   * -  DELETE
-   * R  RENAME
-   */
-  public enum DiffType {
-    CREATE("+"),
-    MODIFY("M"),
-    DELETE("-"),
-    RENAME("R");
-
-    private final String label;
-
-    DiffType(String label) {
-      this.label = label;
-    }
-
-    public String getLabel() {
-      return label;
-    }
-
-    public DiffTypeProto toProtobuf() {
-      return DiffTypeProto.valueOf(this.name());
-    }
-
-    public static DiffType fromProtobuf(final DiffTypeProto type) {
-      return DiffType.valueOf(type.name());
-    }
-  }
-
-  /**
-   * Snapshot diff report entry.
-   */
-  public static final class DiffReportEntry {
-
-    /**
-     * The type of diff.
-     */
-    private final DiffType type;
-
-    /**
-     * Source File/Object path.
-     */
-    private final String sourcePath;
-
-    /**
-     * Destination File/Object path, if this is a re-name operation.
-     */
-    private final String targetPath;
-
-    private DiffReportEntry(final DiffType type, final String sourcePath,
-                            final String targetPath) {
-      this.type = type;
-      this.sourcePath = sourcePath;
-      this.targetPath = targetPath;
-    }
-
-    public static DiffReportEntry of(final DiffType type,
-                                     final String sourcePath) {
-      return of(type, sourcePath, null);
-    }
-
-    public static DiffReportEntry of(final DiffType type,
-                                     final String sourcePath,
-                                     final String targetPath) {
-      return new DiffReportEntry(type, sourcePath, targetPath);
-
-    }
-
-    @Override
-    public String toString() {
-      String str = type.getLabel() + "\t" + sourcePath;
-      if (type == DiffType.RENAME) {
-        str += " -> " + targetPath;
-      }
-      return str;
-    }
-
-    public DiffType getType() {
-      return type;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-      if (this == other) {
-        return true;
-      }
-      if (other instanceof DiffReportEntry) {
-        DiffReportEntry entry = (DiffReportEntry) other;
-        return this.type.equals(entry.getType()) && this.sourcePath
-            .equals(entry.sourcePath) && (this.targetPath != null ?
-            this.targetPath.equals(entry.targetPath) : true);
-      }
-      return false;
-    }
-
-    @Override
-    public int hashCode() {
-      return toString().hashCode();
-    }
-
-    public DiffReportEntryProto toProtobuf() {
-      final DiffReportEntryProto.Builder builder = DiffReportEntryProto
-          .newBuilder();
-      builder.setDiffType(type.toProtobuf()).setSourcePath(sourcePath);
-      if (targetPath != null) {
-        builder.setTargetPath(targetPath);
-      }
-      return builder.build();
-    }
-
-    public static DiffReportEntry fromProtobuf(
-        final DiffReportEntryProto entry) {
-      return of(DiffType.fromProtobuf(entry.getDiffType()),
-          entry.getSourcePath(),
-          entry.hasTargetPath() ? entry.getTargetPath() : null);
-    }
-
-  }
-
-
-  /**
-   * Volume name to which the snapshot bucket belongs.
-   */
-  private final String volumeName;
-
-  /**
-   * Bucket name to which the snapshot belongs.
-   */
-  private final String bucketName;
-  /**
-   * start point of the diff.
-   */
-  private final String fromSnapshot;
-
-  /**
-   * end point of the diff.
-   */
-  private final String toSnapshot;
-
-  /**
-   * list of diff.
-   */
-  private final List<DiffReportEntry> diffList;
-
-  public SnapshotDiffReport(final String volumeName, final String bucketName,
-                            final String fromSnapshot, final String toSnapshot,
-                            List<DiffReportEntry> entryList) {
+  public SnapshotDiffReport(String snapshotRoot, String fromSnapshot,
+      String toSnapshot, List<DiffReportEntry> entryList, String volumeName,
+      String bucketName) {
+    super(snapshotRoot, fromSnapshot, toSnapshot, entryList);
     this.volumeName = volumeName;
     this.bucketName = bucketName;
-    this.fromSnapshot = fromSnapshot;
-    this.toSnapshot = toSnapshot;
-    this.diffList = entryList != null ? entryList : Collections.emptyList();
   }
 
-  public List<DiffReportEntry> getDiffList() {
-    return diffList;
-  }
+  private String volumeName;
+
+  private String bucketName;
 
   @Override
   public String toString() {
     StringBuilder str = new StringBuilder();
-    String from = "snapshot " + fromSnapshot;
-    String to = "snapshot " + toSnapshot;
+    String from = "snapshot " + getFromSnapshot();
+    String to = "snapshot " + getToSnapshot();
     str.append("Difference between ").append(from).append(" and ").append(to)
-        .append(":")
-        .append(LINE_SEPARATOR);
-    for (DiffReportEntry entry : diffList) {
+        .append(":").append(LINE_SEPARATOR);
+    for (DiffReportEntry entry : getDiffList()) {
       str.append(entry.toString()).append(LINE_SEPARATOR);
     }
     return str.toString();
   }
 
-  public SnapshotDiffReportProto toProtobuf() {
-    final SnapshotDiffReportProto.Builder builder = SnapshotDiffReportProto
-        .newBuilder();
-    builder.setVolumeName(volumeName)
-        .setBucketName(bucketName)
-        .setFromSnapshot(fromSnapshot)
-        .setToSnapshot(toSnapshot);
-    builder.addAllDiffList(diffList.stream().map(DiffReportEntry::toProtobuf)
-        .collect(Collectors.toList()));
+  public OzoneManagerProtocolProtos.SnapshotDiffReportProto toProtobuf() {
+    final OzoneManagerProtocolProtos.SnapshotDiffReportProto.Builder builder =
+        OzoneManagerProtocolProtos.SnapshotDiffReportProto.newBuilder();
+    builder.setVolumeName(volumeName).setBucketName(bucketName)
+        .setFromSnapshot(getFromSnapshot()).setToSnapshot(getToSnapshot());
+    builder.addAllDiffList(
+        getDiffList().stream().map(x -> toProtobufDiffReportEntry(x))
+            .collect(Collectors.toList()));
     return builder.build();
   }
 
-  public static SnapshotDiffReport fromProtobuf(
-      final SnapshotDiffReportProto report) {
-    return new SnapshotDiffReport(report.getVolumeName(),
-        report.getBucketName(), report.getFromSnapshot(),
-        report.getToSnapshot(), report.getDiffListList().stream()
-        .map(DiffReportEntry::fromProtobuf).collect(Collectors.toList()));
+  public OzoneManagerProtocolProtos
+      .DiffReportEntryProto toProtobufDiffReportEntry(DiffReportEntry entry) {
+    final OzoneManagerProtocolProtos.DiffReportEntryProto.Builder builder =
+        OzoneManagerProtocolProtos.DiffReportEntryProto.newBuilder();
+    builder.setDiffType(toProtobufDiffType(entry.getType()))
+        .setSourcePath(new String(entry.getSourcePath()));
+    if (entry.getTargetPath() != null) {
+      String targetPath = new String(entry.getTargetPath());
+      builder.setTargetPath(targetPath);
+    }
+    return builder.build();
   }
 
+  public OzoneManagerProtocolProtos.DiffReportEntryProto
+      .DiffTypeProto toProtobufDiffType(DiffType type) {
+    return OzoneManagerProtocolProtos.DiffReportEntryProto
+        .DiffTypeProto.valueOf(type.name());
+  }
+
+  public static SnapshotDiffReport fromProtobuf(
+      final OzoneManagerProtocolProtos.SnapshotDiffReportProto report) {
+    Path bucketPath = new Path(
+        OZONE_URI_DELIMITER + report.getVolumeName()
+            + OZONE_URI_DELIMITER + report.getBucketName());
+    OFSPath path = new OFSPath(bucketPath, new OzoneConfiguration());
+
+    return new SnapshotDiffReport(path.toString(), report.getFromSnapshot(),
+        report.getToSnapshot(), report.getDiffListList().stream()
+        .map(SnapshotDiffReport::fromProtobufDiffReportEntry)
+        .collect(Collectors.toList()), report.getVolumeName(),
+        report.getBucketName());
+  }
+
+  public static DiffType fromProtobufDiffType(
+      final OzoneManagerProtocolProtos.DiffReportEntryProto
+          .DiffTypeProto type) {
+    return DiffType.valueOf(type.name());
+  }
+
+  public static DiffReportEntry fromProtobufDiffReportEntry(
+      final OzoneManagerProtocolProtos.DiffReportEntryProto entry) {
+    if (entry == null) {
+      return null;
+    }
+    DiffType type = fromProtobufDiffType(entry.getDiffType());
+    return type == null ? null :
+        new DiffReportEntry(type, entry.getSourcePath().getBytes(),
+            entry.hasTargetPath() ? entry.getTargetPath().getBytes() : null);
+  }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestDistcpWithSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestDistcpWithSnapshots.java
@@ -1,0 +1,328 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.fs.ozone;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+import org.apache.hadoop.fs.contract.ContractTestUtils;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.TestDataUtil;
+import org.apache.hadoop.ozone.OFSPath;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.ozone.om.OMStorage;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
+import org.apache.hadoop.tools.DistCp;
+import org.apache.hadoop.tools.DistCpOptions;
+import org.apache.hadoop.tools.DistCpSync;
+import org.apache.hadoop.tools.mapred.CopyMapper;
+import org.apache.ozone.test.GenericTestUtils;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Rule;
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.junit.Assert;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.TimeoutException;
+
+import static org.apache.hadoop.ozone.OzoneConsts.OM_SNAPSHOT_DIR;
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
+import static org.apache.hadoop.ozone.OzoneConsts.OM_DB_NAME;
+import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
+
+/**
+ * Testing Distcp with -diff option that uses snapdiff.
+ */
+@RunWith(Parameterized.class)
+public class TestDistcpWithSnapshots {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestDistcpWithSnapshots.class);
+
+  @Rule
+  public Timeout globalTimeout = Timeout.seconds(300);
+  private static OzoneConfiguration conf;
+  private static MiniOzoneCluster cluster = null;
+  private static FileSystem fs;
+  private static BucketLayout bucketLayout;
+  private static String rootPath;
+  private static boolean enableRatis;
+
+  private static File metaDir;
+
+  @Parameterized.Parameters
+  public static Collection<Object[]> data() {
+    return Arrays.asList(
+        new Object[] {true, BucketLayout.FILE_SYSTEM_OPTIMIZED},
+        new Object[] {false, BucketLayout.LEGACY});
+  }
+
+  public TestDistcpWithSnapshots(boolean enableRatis,
+      BucketLayout bucketLayout) {
+    // do nothing
+  }
+
+  @Parameterized.BeforeParam
+  public static void initParam(boolean ratisEnable, BucketLayout layout)
+      throws IOException, InterruptedException, TimeoutException {
+    // Initialize the cluster before EACH set of parameters
+    enableRatis = ratisEnable;
+    bucketLayout = layout;
+    initClusterAndEnv();
+  }
+
+  @Parameterized.AfterParam
+  public static void teardownParam() {
+    // Tear down the cluster after EACH set of parameters
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+    IOUtils.closeQuietly(fs);
+  }
+
+  public static void initClusterAndEnv()
+      throws IOException, InterruptedException, TimeoutException {
+    conf = new OzoneConfiguration();
+    conf.setBoolean(OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY, enableRatis);
+    bucketLayout = BucketLayout.FILE_SYSTEM_OPTIMIZED;
+    conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT, bucketLayout.name());
+    cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(5).build();
+    cluster.waitForClusterToBeReady();
+
+    rootPath = String.format("%s://%s/", OzoneConsts.OZONE_OFS_URI_SCHEME,
+        conf.get(OZONE_OM_ADDRESS_KEY));
+
+    // Set the fs.defaultFS and start the filesystem
+    conf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);
+    conf.setClass("distcp.sync.class", OzoneDistcpSync.class,
+        DistCpSync.class);
+    fs = FileSystem.get(conf);
+    metaDir = OMStorage.getOmDbDir(conf);
+  }
+
+  @AfterClass
+  public static void shutdown() {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
+  @Test
+  public void testDistcpWithSnapDiff() throws Exception {
+    Path srcBucketPath = createAndGetBucketPath();
+    Path insideSrcBucket = new Path(srcBucketPath, "*");
+    Path dstBucketPath = createAndGetBucketPath();
+    // create 2 files on source
+    createFiles(srcBucketPath, 2);
+    // Create target directory/bucket
+    fs.mkdirs(dstBucketPath);
+
+    // perform normal distcp
+    final DistCpOptions options =
+        new DistCpOptions.Builder(Collections.singletonList(insideSrcBucket),
+            dstBucketPath).build();
+    options.appendToConf(conf);
+    Job distcpJob = new DistCp(conf, options).execute();
+    verifyCopy(dstBucketPath, distcpJob, 2, 2);
+
+    // take Snapshot snap1 on both source and target
+    createSnapshot(srcBucketPath, "snap1");
+    createSnapshot(dstBucketPath, "snap1");
+
+
+
+    // create another file on src and take snapshot snap2 on source
+    createFiles(srcBucketPath, 1);
+    Assert.assertEquals(3, fs.listStatus(srcBucketPath).length);
+    createSnapshot(srcBucketPath, "snap2");
+
+    // perform distcp providing snapshot snap1.snap2 as arguments to
+    // copy only diff b/w them.
+    final DistCpOptions options2 =
+        new DistCpOptions.Builder(Collections.singletonList(srcBucketPath),
+            dstBucketPath).withUseDiff("snap1", "snap2").withSyncFolder(true)
+            .build();
+
+    distcpJob = new DistCp(conf, options2).execute();
+    verifyCopy(dstBucketPath, distcpJob, 1, 3);
+  }
+
+  @NotNull
+  private static Path createAndGetBucketPath() throws IOException {
+    OzoneBucket bucket =
+        TestDataUtil.createVolumeAndBucket(cluster, bucketLayout);
+    Path volumePath =
+        new Path(OZONE_URI_DELIMITER, bucket.getVolumeName());
+    Path bucketPath = new Path(volumePath, bucket.getName());
+    return bucketPath;
+  }
+
+  @Test
+  public void testDistcpWithSnapDiff2() throws Exception {
+    Path srcBucketPath = createAndGetBucketPath();
+    Path insideSrcBucket = new Path(srcBucketPath, "*");
+    Path dstBucketPath = createAndGetBucketPath();
+    // create 2 files on source
+    createFiles(srcBucketPath, 2);
+    // Create target directory/bucket
+    fs.mkdirs(dstBucketPath);
+
+    // perform normal distcp
+    final DistCpOptions options =
+        new DistCpOptions.Builder(Collections.singletonList(insideSrcBucket),
+            dstBucketPath).build();
+    options.appendToConf(conf);
+    Job distcpJob = new DistCp(conf, options).execute();
+    verifyCopy(dstBucketPath, distcpJob, 2, 2);
+
+    // take Snapshot snap1 on both source and target
+    createSnapshot(srcBucketPath, "snap1");
+    createSnapshot(dstBucketPath, "snap1");
+
+    // delete 1 file on source
+    deleteFiles(srcBucketPath, 1);
+    Assert.assertEquals(1, fs.listStatus(srcBucketPath).length);
+    createSnapshot(srcBucketPath, "snap2");
+
+    // perform distcp providing snapshot snap1.snap2 as arguments to
+    // copy only diff b/w them.
+    final DistCpOptions options2 =
+        new DistCpOptions.Builder(Collections.singletonList(srcBucketPath),
+            dstBucketPath).withUseDiff("snap1", "snap2").withSyncFolder(true)
+            .build();
+
+    distcpJob = new DistCp(conf, options2).execute();
+    verifyCopy(dstBucketPath, distcpJob, 0, 1);
+  }
+
+  @Test
+  public void testDistcpWithSnapDiff3() throws Exception {
+    Path srcBucketPath = createAndGetBucketPath();
+    Path insideSrcBucket = new Path(srcBucketPath, "*");
+    Path dstBucketPath = createAndGetBucketPath();
+    // create 2 files on source
+    createFiles(srcBucketPath, 2);
+    // Create target directory/bucket
+    fs.mkdirs(dstBucketPath);
+
+    // perform normal distcp
+    final DistCpOptions options =
+        new DistCpOptions.Builder(Collections.singletonList(insideSrcBucket),
+            dstBucketPath).build();
+    options.appendToConf(conf);
+    Job distcpJob = new DistCp(conf, options).execute();
+    verifyCopy(dstBucketPath, distcpJob, 2, 2);
+
+    // take Snapshot snap1 on both source and target
+    createSnapshot(srcBucketPath, "snap1");
+    createSnapshot(dstBucketPath, "snap1");
+
+    // delete 1 file on source
+    renameFiles(srcBucketPath, 1);
+    Assert.assertEquals(2, fs.listStatus(srcBucketPath).length);
+    createSnapshot(srcBucketPath, "snap2");
+
+    // perform distcp providing snapshot snap1.snap2 as arguments to
+    // copy only diff b/w them.
+    final DistCpOptions options2 =
+        new DistCpOptions.Builder(Collections.singletonList(srcBucketPath),
+            dstBucketPath).withUseDiff("snap1", "snap2").withSyncFolder(true)
+            .build();
+
+    distcpJob = new DistCp(conf, options2).execute();
+    verifyCopy(dstBucketPath, distcpJob, 0, 2);
+  }
+
+  private void deleteFiles(Path path, int fileCount) throws IOException {
+    FileStatus[] filesInPath = fs.listStatus(path);
+    Assert.assertTrue("Cannot delete more files than what is existing",
+        fileCount <= filesInPath.length);
+    for (int i = 0; i < fileCount; i++) {
+      Path toDelete = filesInPath[i].getPath();
+      fs.delete(toDelete, false);
+    }
+  }
+
+  private void renameFiles(Path path, int fileCount) throws IOException {
+    FileStatus[] filesInPath = fs.listStatus(path);
+    Assert.assertTrue("Cannot delete more files than what is existing",
+        fileCount <= filesInPath.length);
+    for (int i = 0; i < fileCount; i++) {
+      Path from = filesInPath[i].getPath();
+      Path to = new Path(from + "_renamed");
+      fs.rename(from, to);
+    }
+  }
+
+  private static void verifyCopy(Path dstBucketPath, Job distcpJob,
+      long expectedFilesToBeCopied, long expectedTotalFilesInDest)
+      throws IOException {
+    long filesCopied =
+        distcpJob.getCounters().findCounter(CopyMapper.Counter.COPY).getValue();
+    FileStatus[] destinationFileStatus = fs.listStatus(dstBucketPath);
+    Assert.assertEquals(expectedTotalFilesInDest, destinationFileStatus.length);
+    Assert.assertEquals(expectedFilesToBeCopied, filesCopied);
+  }
+
+  private static void createFiles(Path srcBucketPath, int fileCount)
+      throws IOException {
+    for (int i = 1; i <= fileCount; i++) {
+      String keyName = "key" + RandomStringUtils.randomNumeric(5);
+      Path file =
+          new Path(srcBucketPath, keyName);
+      ContractTestUtils.touch(fs, file);
+    }
+  }
+
+  private Path createSnapshot(Path path, String snapshotName)
+      throws IOException, InterruptedException, TimeoutException {
+    OFSPath ofsPath = new OFSPath(path, conf);
+    String volume = ofsPath.getVolumeName();
+    String bucket = ofsPath.getBucketName();
+    Path snapPath = fs.createSnapshot(path, snapshotName);
+    SnapshotInfo snapshotInfo =
+        cluster.getOzoneManager().getMetadataManager().getSnapshotInfoTable()
+            .get(SnapshotInfo.getTableKey(volume, bucket, snapshotName));
+    String snapshotDirName =
+        metaDir + OM_KEY_PREFIX + OM_SNAPSHOT_DIR + OM_KEY_PREFIX
+            + OM_DB_NAME + snapshotInfo.getCheckpointDirName() + OM_KEY_PREFIX
+            + "CURRENT";
+    GenericTestUtils.waitFor(() -> new File(snapshotDirName).exists(), 1000,
+        120000);
+    return snapPath;
+  }
+
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
@@ -454,12 +454,16 @@ public class TestOmSnapshot {
     // Diff should have 2 entries
     SnapshotDiffReport diff2 = store.snapshotDiff(volume, bucket, snap2, snap3);
     Assert.assertEquals(2, diff2.getDiffList().size());
-    Assert.assertTrue(diff2.getDiffList().contains(
-        SnapshotDiffReport.DiffReportEntry
-            .of(SnapshotDiffReport.DiffType.CREATE, key2)));
-    Assert.assertTrue(diff2.getDiffList().contains(
-        SnapshotDiffReport.DiffReportEntry
-            .of(SnapshotDiffReport.DiffType.DELETE, key1)));
+    org.apache.hadoop.hdfs.protocol.SnapshotDiffReport.DiffReportEntry del =
+        new org.apache.hadoop.hdfs.protocol.SnapshotDiffReport.DiffReportEntry(
+            SnapshotDiffReport.DiffType.DELETE, key1.getBytes());
+    org.apache.hadoop.hdfs.protocol.SnapshotDiffReport.DiffReportEntry creat =
+        new org.apache.hadoop.hdfs.protocol.SnapshotDiffReport.DiffReportEntry(
+            SnapshotDiffReport.DiffType.CREATE, key2.getBytes());
+
+    Assert.assertTrue(diff2.getDiffList().contains(creat));
+
+    Assert.assertTrue(diff2.getDiffList().contains(del));
 
     // Rename Key2
     String key2Renamed = key2 + "_renamed";
@@ -469,8 +473,9 @@ public class TestOmSnapshot {
     SnapshotDiffReport diff3 = store.snapshotDiff(volume, bucket, snap3, snap4);
     Assert.assertEquals(1, diff3.getDiffList().size());
     Assert.assertTrue(diff3.getDiffList().contains(
-        SnapshotDiffReport.DiffReportEntry
-            .of(SnapshotDiffReport.DiffType.RENAME, key2, key2Renamed)));
+        new org.apache.hadoop.hdfs.protocol.SnapshotDiffReport.DiffReportEntry(
+            SnapshotDiffReport.DiffType.RENAME, key2.getBytes(),
+            key2Renamed.getBytes())));
 
 
     // Create a directory
@@ -486,8 +491,8 @@ public class TestOmSnapshot {
       dir1 = dir1 + OM_KEY_PREFIX;
     }
     Assert.assertTrue(diff4.getDiffList().contains(
-        SnapshotDiffReport.DiffReportEntry
-            .of(SnapshotDiffReport.DiffType.CREATE, dir1)));
+        new org.apache.hadoop.hdfs.protocol.SnapshotDiffReport.DiffReportEntry(
+            SnapshotDiffReport.DiffType.CREATE, dir1.getBytes())));
 
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.hadoop.hdds.utils.db.RocksDBConfiguration;
 import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.hdds.utils.db.RDBCheckpointManager;
 import org.apache.hadoop.hdds.utils.db.Table.KeyValue;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.hdds.utils.db.TypedTable;
@@ -302,14 +303,20 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
   }
 
   // metadata constructor for snapshots
-  private OmMetadataManagerImpl(OzoneConfiguration conf, String snapshotDirName)
+  private OmMetadataManagerImpl(OzoneConfiguration conf, String snapshotDirName,
+      boolean isSnapshotInCache)
       throws IOException {
     lock = new OmReadOnlyLock();
     omEpoch = 0;
     String snapshotDir = OMStorage.getOmDbDir(conf) +
         OM_KEY_PREFIX + OM_SNAPSHOT_DIR;
-    setStore(loadDB(conf, new File(snapshotDir),
-        OM_DB_NAME + snapshotDirName, true));
+    File metaDir = new File(snapshotDir);
+    String dbName = OM_DB_NAME + snapshotDirName;
+    if (isSnapshotInCache) {
+      File checkpoint = Paths.get(metaDir.toPath().toString(), dbName).toFile();
+      RDBCheckpointManager.waitForCheckpointDirectoryExist(checkpoint);
+    }
+    setStore(loadDB(conf, metaDir, dbName, true));
     initializeOmTables(false);
   }
 
@@ -322,9 +329,10 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
    * @throws IOException
    */
   public static OmMetadataManagerImpl createSnapshotMetadataManager(
-      OzoneConfiguration conf, String snapshotDirName) throws IOException {
-    OmMetadataManagerImpl smm = new OmMetadataManagerImpl(conf,
-        snapshotDirName);
+      OzoneConfiguration conf, String snapshotDirName,
+      boolean isSnapshotInCache) throws IOException {
+    OmMetadataManagerImpl smm = new OmMetadataManagerImpl(conf, snapshotDirName,
+        isSnapshotInCache);
     return smm;
   }
 
@@ -905,6 +913,22 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
       OmKeyInfo omKeyInfo = entry.getValue().getCacheValue();
       // Making sure that entry is not for delete key request.
       if (key.startsWith(keyPrefix) && omKeyInfo != null) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static boolean isSnapshotPresentInTableCache(String keyPrefix, Table table) {
+    Iterator<Map.Entry<CacheKey<String>, CacheValue<SnapshotInfo>>> iterator =
+        table.cacheIterator();
+    while (iterator.hasNext()) {
+      Map.Entry<CacheKey<String>, CacheValue<SnapshotInfo>> entry =
+          iterator.next();
+      String key = entry.getKey().getCacheKey();
+      SnapshotInfo snapshotInfo = entry.getValue().getCacheValue();
+      // Making sure that entry is not for delete key request.
+      if (key.startsWith(keyPrefix) && snapshotInfo != null) {
         return true;
       }
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -85,7 +85,10 @@ public final class OmSnapshotManager {
         SnapshotInfo snapshotInfo;
         // see if the snapshot exists
         snapshotInfo = getSnapshotInfo(snapshotTableKey);
-
+        boolean isSnapshotInCache =
+            OmMetadataManagerImpl.isSnapshotPresentInTableCache(
+                snapshotTableKey,
+                ozoneManager.getMetadataManager().getSnapshotInfoTable());
         // read in the snapshot
         OzoneConfiguration conf = ozoneManager.getConfiguration();
         OMMetadataManager snapshotMetadataManager;
@@ -95,8 +98,8 @@ public final class OmSnapshotManager {
         // that
         try {
           snapshotMetadataManager = OmMetadataManagerImpl
-              .createSnapshotMetadataManager(
-              conf, snapshotInfo.getCheckpointDirName());
+              .createSnapshotMetadataManager(conf,
+                  snapshotInfo.getCheckpointDirName(), isSnapshotInCache);
         } catch (IOException e) {
           LOG.error("Failed to retrieve snapshot: {}, {}", snapshotTableKey, e);
           throw e;
@@ -152,6 +155,9 @@ public final class OmSnapshotManager {
 
     final DBCheckpoint dbCheckpoint = store.getSnapshot(
         snapshotInfo.getCheckpointDirName());
+
+    LOG.info("Created checkpoint : {} for snapshot {}",
+        dbCheckpoint.getCheckpointLocation(), snapshotInfo.getName());
 
     // Write snapshot generation (latest sequence number) to compaction log.
     // This will be used for DAG reconstruction as snapshotGeneration.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -440,10 +440,10 @@ public final class OzoneManagerDoubleBuffer {
       // 1. It is first element in the response,
       // 2. Current request is createSnapshot request.
       // 3. Previous request was createSnapshot request.
-      if (response.isEmpty() ||
-          omResponse.getCreateSnapshotResponse() != null ||
-          (previousOmResponse != null &&
-              previousOmResponse.getCreateSnapshotResponse() != null)) {
+      if (response.isEmpty() || omResponse.getCreateSnapshotResponse()
+          .hasSnapshotInfo() || (previousOmResponse != null &&
+          previousOmResponse.getCreateSnapshotResponse()
+          .hasSnapshotInfo())) {
         response.add(new LinkedList<>());
       }
 

--- a/hadoop-ozone/ozonefs-common/pom.xml
+++ b/hadoop-ozone/ozonefs-common/pom.xml
@@ -110,5 +110,10 @@
       <artifactId>powermock-api-mockito</artifactId>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-distcp</artifactId>
+        <scope>provided</scope>
+      </dependency>
   </dependencies>
 </project>

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -63,6 +63,7 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
+import org.apache.hadoop.ozone.snapshot.SnapshotDiffReport;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenRenewer;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
@@ -645,5 +646,13 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
     return objectStore.createSnapshot(ofsPath.getVolumeName(),
         ofsPath.getBucketName(),
         snapshotName);
+  }
+
+  @Override
+  public SnapshotDiffReport getSnapshotDiffReport(Path snapshotDir,
+      String fromSnapshot, String toSnapshot) throws IOException {
+    OFSPath ofsPath = new OFSPath(snapshotDir, config);
+    return objectStore.snapshotDiff(ofsPath.getVolumeName(),
+        ofsPath.getBucketName(), fromSnapshot, toSnapshot);
   }
 }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -73,6 +73,7 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
+import org.apache.hadoop.ozone.snapshot.SnapshotDiffReport;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenRenewer;
@@ -1167,5 +1168,13 @@ public class BasicRootedOzoneClientAdapterImpl
     return proxy.createSnapshot(ofsPath.getVolumeName(),
             ofsPath.getBucketName(),
             snapshotName);
+  }
+
+  @Override
+  public SnapshotDiffReport getSnapshotDiffReport(Path snapshotDir,
+      String fromSnapshot, String toSnapshot) throws IOException {
+    OFSPath ofsPath = new OFSPath(snapshotDir, config);
+    return proxy.snapshotDiff(ofsPath.getVolumeName(), ofsPath.getBucketName(),
+        fromSnapshot, toSnapshot);
   }
 }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.StorageUnit;
 import org.apache.hadoop.hdds.utils.LegacyHadoopConfigurationSource;
+import org.apache.hadoop.hdfs.protocol.SnapshotDiffReport;
 import org.apache.hadoop.ozone.OFSPath;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.client.OzoneBucket;
@@ -1415,6 +1416,15 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
     return new ContentSummary.Builder().length(summary[0]).
         fileCount(summary[2]).directoryCount(summary[3]).
         spaceConsumed(summary[1]).build();
+  }
+
+  public SnapshotDiffReport getSnapshotDiffReport(final Path snapshotDir,
+      final String fromSnapshot, final String toSnapshot) throws IOException {
+    OFSPath ofsPath =
+        new OFSPath(snapshotDir, OzoneConfiguration.of(getConf()));
+    Preconditions.checkArgument(ofsPath.isBucket(),
+        "Unsupported : Path is not a bucket");
+    return adapter.getSnapshotDiffReport(snapshotDir, fromSnapshot, toSnapshot);
   }
 
 }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapter.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapter.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.crypto.key.KeyProvider;
 import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
+import org.apache.hadoop.ozone.snapshot.SnapshotDiffReport;
 import org.apache.hadoop.security.token.Token;
 
 /**
@@ -86,4 +87,7 @@ public interface OzoneClientAdapter {
   FileChecksum getFileChecksum(String keyName, long length) throws IOException;
 
   String createSnapshot(String pathStr, String snapshotName) throws IOException;
+
+  SnapshotDiffReport getSnapshotDiffReport(Path snapshotDir,
+      String fromSnapshot, String toSnapshot) throws IOException;
 }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneDistcpSync.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneDistcpSync.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.fs.ozone;
+
+
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.protocol.SnapshotDiffReport;
+import org.apache.hadoop.tools.DistCpSync;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+import java.io.IOException;
+
+/**
+ * Ozone's DistcpSync implementation.
+ */
+public class OzoneDistcpSync extends DistCpSync {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(OzoneDistcpSync.class);
+
+  @Override
+  public void checkFilesystemSupport(FileSystem srcFs, FileSystem tgtFs) {
+    if (!(srcFs instanceof BasicRootedOzoneFileSystem)) {
+      throw new IllegalArgumentException(
+          "Unsupported source file system: " + srcFs.getScheme() + "://. "
+              + "Supported file systems: ofs. If scheme is either " +
+              "hdfs/webhdfs use respective distcp.sync.class.name " +
+              "in the configuration ");
+    }
+    if (!(tgtFs instanceof BasicRootedOzoneFileSystem)) {
+      throw new IllegalArgumentException(
+          "Unsupported source file system: " + srcFs.getScheme() + "://. "
+              + "Supported file systems: ofs. If scheme is either " +
+              "hdfs/webhdfs use respective distcp.sync.class.name " +
+              "in the configuration ");
+    }
+
+  }
+
+  @Override
+  protected SnapshotDiffReport getSnapshotDiffReport(Path ssDir, FileSystem fs,
+      String from, String to) throws IOException {
+    if (fs instanceof BasicRootedOzoneFileSystem) {
+      BasicRootedOzoneFileSystem ofs = (BasicRootedOzoneFileSystem) fs;
+      return ofs.getSnapshotDiffReport(ssDir, from, to);
+    } else {
+      throw new IllegalArgumentException(
+          "Unsupported source file system: " + fs.getScheme() + "://. "
+              + "Supported file systems: ofs. If scheme is either " +
+              "hdfs/webhdfs use respective distcp.sync.class.name " +
+              "in the configuration ");
+    }
+  }
+
+  @Override
+  protected boolean checkNoChange(FileSystem fs, Path path) {
+    // TODO fix HDDS-7905.
+    return true;
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,8 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
   <properties>
     <hadoop2.version>2.7.3</hadoop2.version>
-    <hadoop.version>3.3.4</hadoop.version>
+    <!--<version>3.4.0-SNAPSHOT</version>-->
+    <hadoop.version>3.4.0-SNAPSHOT</hadoop.version>
 
     <!-- version for hdds/ozone components -->
     <hdds.version>${ozone.version}</hdds.version>
@@ -179,7 +180,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <disruptor.version>3.4.2</disruptor.version>
     <reload4j.version>1.2.22</reload4j.version>
 
-    <kerby.version>1.0.1</kerby.version>
+    <kerby.version>2.0.2</kerby.version>
     <kotlin.version>1.6.21</kotlin.version>
     <metainf-services.version>1.8</metainf-services.version>
     <picocli.version>4.6.1</picocli.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Main changes
1. Make `org.apache.hadoop.ozone.snapshot.SnapshotDiffReport` extend `org.apache.hadoop.hdfs.protocol.SnapshotDiffReport`
2. Add Ozone's DistcpSync implementation that provides flexibility to use Ozone specific checks/ functions.

Changes to pom.xml
1. added `hadoop-distcp` dependency to `ozonefs-common`
2. added `hadoop-hdfs-client` to `ozone-common` (required to access `org.apache.hadoop.hdfs.protocol.SnapshotDiffReport`)
3. update `hadoop` version to` 3.4.0-Snapshot` that contains changes for distcp to work with ozone with snapshots.
4. Had to update  `kerby.version` as it was throwing Dependency convergence error for org.apache.kerby:kerb-core:jar:1.0.1  since latest version of hadoop uses this version.


## What is the link to the Apache JIRA


## How was this patch tested?
Unit tests